### PR TITLE
Use union type instead of intersection; update statusCode to status

### DIFF
--- a/src/Http.test.ts
+++ b/src/Http.test.ts
@@ -1,6 +1,8 @@
+import { either } from 'fp-ts'
 import * as E from 'fp-ts/Either'
+import { identity } from 'io-ts'
 import * as $C from './Cache'
-import { cache, mock } from './Http'
+import { cache, HttpError, HttpErrorC, HttpResponse, mock } from './Http'
 
 describe('Http', () => {
   describe('cache', () => {
@@ -24,6 +26,66 @@ describe('Http', () => {
         const c = await http.get('foo')()
 
         expect(c).not.toStrictEqual(h)
+      })
+    })
+  })
+
+  describe('HttpErrorC', () => {
+    const response: HttpResponse = {
+      url: 'https://example.com/',
+      status: 500,
+      headers: {
+        'access-control-allow-origin': '*',
+        charset: 'utf-8',
+        'content-type': 'application/json',
+      },
+      body: '',
+    }
+    describe('without type given', () => {
+      const codec = HttpErrorC()
+      describe('given "Error" instance', () => {
+        it('should not match type', async () => {
+          const obj = new Error('Error messsage')
+          expect(codec.is(obj)).toBeFalsy()
+          expect(codec.validate(obj, [])._tag).toStrictEqual('Left')
+        })
+      })
+      describe('given object with "HttpResponse" property', () => {
+        it('should not match type', async () => {
+          const obj = { response }
+          expect(codec.is(obj)).toBeFalsy()
+          expect(codec.validate(obj, [])._tag).toStrictEqual('Left')
+        })
+      })
+      describe('given "HttpError" instance', () => {
+        it('should match type successfully', async () => {
+          const obj = new HttpError(response)
+          expect(codec.is(obj)).toBeTruthy()
+          expect(codec.validate(obj, [])._tag).toStrictEqual('Right')
+          expect(
+            either.match(identity, identity)(codec.validate(obj, [])),
+          ).toStrictEqual(obj)
+        })
+      })
+    })
+    describe('given "BadRequest" type', () => {
+      const codec = HttpErrorC('BadRequest')
+      describe('given "HttpError" instance with "500" status code', () => {
+        it('should match type successfully', async () => {
+          const obj = new HttpError(response)
+          expect(codec.is(obj)).toBeFalsy()
+          expect(codec.validate(obj, [])._tag).toStrictEqual('Left')
+        })
+      })
+      describe('given "HttpError" instance with "400" status code', () => {
+        it('should match type successfully', async () => {
+          const obj = new HttpError({ ...response, status: 400 })
+          expect(codec.is(obj)).toBeTruthy()
+          expect(codec.validate(obj, [])._tag).toStrictEqual('Right')
+          expect(
+            either.match(identity, identity)(codec.validate(obj, [])),
+          ).toStrictEqual(obj)
+        })
       })
     })
   })

--- a/src/Http.ts
+++ b/src/Http.ts
@@ -87,19 +87,17 @@ export const HttpResponseC = <C extends t.Mixed>(codec: C) =>
 
 const is =
   <A extends keyof typeof ERRORS>(type?: A) =>
-  (u: unknown): u is HttpError => {
-    return (
-      $Er.ErrorC.is(u) &&
-      t
-        .type({
-          response: t.intersection([
-            HttpResponseC(t.unknown),
-            t.type({ status: type ? t.literal(ERRORS[type]) : t.number }),
-          ]),
-        })
-        .is({ ...u })
-    )
-  }
+  (u: unknown): u is HttpError =>
+    $Er.ErrorC.is(u) &&
+    t
+      .type({
+        response: t.intersection([
+          HttpResponseC(t.unknown),
+          t.type({ status: type ? t.literal(ERRORS[type]) : t.number }),
+        ]),
+      })
+      .is({ ...u })
+
 export const HttpErrorC = <A extends keyof typeof ERRORS>(type?: A) =>
   new t.Type(
     `Http${type || ''}Error`,

--- a/src/Http.ts
+++ b/src/Http.ts
@@ -86,13 +86,13 @@ export const HttpResponseC = <C extends t.Mixed>(codec: C) =>
   )
 
 export const HttpErrorC = <A extends keyof typeof ERRORS>(type?: A) =>
-  t.intersection(
+  t.union(
     [
       $Er.ErrorC,
       t.type({
         response: t.intersection([
           HttpResponseC(t.unknown),
-          t.type({ statusCode: type ? t.literal(ERRORS[type]) : t.number }),
+          t.type({ status: type ? t.literal(ERRORS[type]) : t.number }),
         ]),
       }),
     ],


### PR DESCRIPTION
- Changed `HttpErrorC` codec from an intersection type to union type
- Changed former `statusCode` key to `status`.