### PR TITLE
Define Matrix brand type to fix compilation

### DIFF
--- a/src/Matrix.ts
+++ b/src/Matrix.ts
@@ -9,9 +9,13 @@ import * as $Eq from './Eq'
 import * as $RA from './ReadonlyArray'
 import * as $RR from './ReadonlyRecord'
 
+interface MatrixBrand {
+  readonly Matrix: unique symbol
+}
+
 export type Matrix<A> = t.Branded<
   ReadonlyArray<RNEA.ReadonlyNonEmptyArray<A>>,
-  { readonly Matrix: unique symbol }
+  MatrixBrand
 >
 
 const is =


### PR DESCRIPTION
This allows deduplicating the brand `unique symbol` on compilation:
```typescript
import * as RNEA from 'fp-ts/ReadonlyNonEmptyArray';
import * as t from 'io-ts';
interface MatrixBrand {
    readonly Matrix: unique symbol;
}
export declare type Matrix<A> = t.Branded<ReadonlyArray<RNEA.ReadonlyNonEmptyArray<A>>, MatrixBrand>;
export declare const MatrixC: <C extends t.Mixed>(item: C) => t.BrandC<t.ReadonlyArrayC<import("io-ts-types").ReadonlyNonEmptyArrayC<C>>, MatrixBrand>;
```