### PR TITLE
Avoid open handles on tests execution

### DIFF
--- a/src/Http.test.ts
+++ b/src/Http.test.ts
@@ -4,6 +4,8 @@ import { identity } from 'io-ts'
 import * as $C from './Cache'
 import { cache, HttpError, HttpErrorC, HttpResponse, mock } from './Http'
 
+jest.useFakeTimers()
+
 describe('Http', () => {
   describe('cache', () => {
     const _cache = $C.memory()


### PR DESCRIPTION
`$cache.memory` executes `setTimeout` to handle cache items TTL. We need to tell Jest not to use real timers.