### PR TITLE
Deprecate Got HTTP client

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,6 @@ Additional packages are required shall you want to use specific abstractions:
 - [`memcached`](https://www.npmjs.com/package/memcached) and [`@types/memcached`](https://www.npmjs.com/package/@types/memcached) (`cache/Memcached`)
 - [`redis`](https://www.npmjs.com/package/redis) and [`@types/redis`](https://www.npmjs.com/package/@types/redis) (`cache/Redis`)
 - [`axios`](https://www.npmjs.com/package/axios) (`http/Axios`)
-- [`got`](https://www.npmjs.com/package/got) (`http/Got`)
 - [`@slynova/flydrive`](https://www.npmjs.com/package/@slynova/flydrive) (`storage/Flydrive`)
 
 ### Usage

--- a/src/http/Got.ts
+++ b/src/http/Got.ts
@@ -60,6 +60,9 @@ const request = (
     ),
   )
 
+/**
+ * @deprecated Use `$axios` instead
+ */
 export const $got = (_got: Got): $H.Http => ({
   delete: (url, options) => request(_got, 'delete', url, options),
   get: (url, options) => request(_got, 'get', url, options),


### PR DESCRIPTION
Got misses at least one feature supported by Axios: buffer response handling. Since its implementation doesn't provide any benefit comparing to Axios, let's deprecate it.