### PR TITLE
Capitalize Struct

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+
+- Add `Struct` type.
+
+### Deprecated
+
+- Deprecate `struct` (use `Struct` instead).
+
 ## [0.1.2](https://github.com/facile-it/fortepiano/compare/v0.1.1...v0.1.2) - 2022-04-29
 
 ### Added

--- a/src/Console.ts
+++ b/src/Console.ts
@@ -47,11 +47,11 @@ export const group = _multipleArgs('group')
 export const groupCollapsed = _multipleArgs('groupCollapsed')
 export const groupEnd = _noArgs('groupEnd')
 
-export function table<A extends $S.struct, K extends keyof A>(
+export function table<A extends $S.Struct, K extends keyof A>(
   data: ReadonlyArray<A> | RR.ReadonlyRecord<string, A>,
   columns?: ReadonlyArray<K>,
 ): IO.IO<void>
-export function table(data: $S.struct | ReadonlyArray<unknown>): IO.IO<void>
+export function table(data: $S.Struct | ReadonlyArray<unknown>): IO.IO<void>
 export function table(
   a?: undefined | boolean | number | string,
   ...as: ReadonlyArray<unknown>

--- a/src/Http.ts
+++ b/src/Http.ts
@@ -7,7 +7,6 @@ import * as RR from 'fp-ts/ReadonlyRecord'
 import * as TE from 'fp-ts/TaskEither'
 import * as t from 'io-ts'
 import { Json } from 'io-ts-types'
-import * as $T from './Type'
 import * as $C from './Cache'
 import * as $Er from './Error'
 import { mock } from './http/Mock'
@@ -15,6 +14,7 @@ import * as $L from './Log'
 import * as $R from './Random'
 import * as $Stri from './string'
 import * as $Stru from './struct'
+import * as $T from './Type'
 
 const ERRORS = {
   BadRequest: 400,
@@ -48,7 +48,7 @@ export class HttpError extends Error {
 }
 
 export interface HttpOptions {
-  readonly body?: $Stru.struct | Buffer
+  readonly body?: $Stru.Struct | Buffer
   readonly headers?: RR.ReadonlyRecord<string, string>
   readonly json?: boolean
   readonly buffer?: boolean

--- a/src/Mock.ts
+++ b/src/Mock.ts
@@ -70,8 +70,8 @@ export const Pointed: P.Pointed1<URI> = {
             (_a) =>
               $t.struct.is(a) && $t.struct.is(_a)
                 ? (pipe(_a, $St.filterDeep(Pr.not(t.undefined.is)), (_a) =>
-                    $St.patch<A & $St.struct, PartialDeep<A & $St.struct>>(
-                      _a as PartialDeep<A & $St.struct>,
+                    $St.patch<A & $St.Struct, PartialDeep<A & $St.Struct>>(
+                      _a as PartialDeep<A & $St.Struct>,
                     )(a),
                   ) as A)
                 : (_a as A),

--- a/src/Reader.ts
+++ b/src/Reader.ts
@@ -3,12 +3,12 @@ import * as R from 'fp-ts/Reader'
 import * as $S from './struct'
 
 export const pick =
-  <R extends $S.struct>() =>
+  <R extends $S.Struct>() =>
   <K extends keyof R>(k: K) =>
     R.asks<Pick<R, K>, Pick<R, K>[K]>($S.lookup(k))
 
 export const picks =
-  <R extends $S.struct>() =>
+  <R extends $S.Struct>() =>
   <K extends keyof R, B>(
     k: K,
     f: (r: Pick<R, K>[K]) => R.Reader<Pick<R, K>, B>,
@@ -16,7 +16,7 @@ export const picks =
     picksW<R>()(k, f)
 
 export const picksW =
-  <R1 extends $S.struct>() =>
+  <R1 extends $S.Struct>() =>
   <K extends keyof R1, R2, B>(
     k: K,
     f: (r: Pick<R1, K>[K]) => R.Reader<R2, B>,

--- a/src/ReaderEither.ts
+++ b/src/ReaderEither.ts
@@ -5,12 +5,12 @@ import * as RE from 'fp-ts/ReaderEither'
 import * as $S from './struct'
 
 export const pick =
-  <R extends $S.struct>() =>
+  <R extends $S.Struct>() =>
   <K extends keyof R>(k: K) =>
     RE.asks((r: Pick<R, K>) => r[k])
 
 export const picks =
-  <R extends $S.struct>() =>
+  <R extends $S.Struct>() =>
   <K extends keyof R, E, B>(
     k: K,
     f: (r: Pick<R, K>[K]) => RE.ReaderEither<Pick<R, K>, E, B>,
@@ -18,7 +18,7 @@ export const picks =
     picksW<R>()(k, f)
 
 export const picksW =
-  <R1 extends $S.struct>() =>
+  <R1 extends $S.Struct>() =>
   <K extends keyof R1, R2, E, B>(
     k: K,
     f: (r: Pick<R1, K>[K]) => RE.ReaderEither<R2, E, B>,
@@ -26,12 +26,12 @@ export const picksW =
     pipe(pick<R1>()(k), RE.chainW(f))
 
 export const picksOptionK =
-  <R extends $S.struct>() =>
+  <R extends $S.Struct>() =>
   <E>(onNone: Lazy<E>) =>
   <K extends keyof R, B>(k: K, f: (r: Pick<R, K>[K]) => O.Option<B>) =>
     picks<R>()(k, RE.fromOptionK(onNone)(f))
 
 export const picksEitherK =
-  <R extends $S.struct>() =>
+  <R extends $S.Struct>() =>
   <K extends keyof R, _E, B>(k: K, f: (r: Pick<R, K>[K]) => E.Either<_E, B>) =>
     picks<R>()(k, RE.fromEitherK(f))

--- a/src/ReaderTask.ts
+++ b/src/ReaderTask.ts
@@ -5,12 +5,12 @@ import * as T from 'fp-ts/Task'
 import * as $S from './struct'
 
 export const pick =
-  <R extends $S.struct>() =>
+  <R extends $S.Struct>() =>
   <K extends keyof R>(k: K) =>
     RT.asks<Pick<R, K>, Pick<R, K>[K]>($S.lookup(k))
 
 export const picks =
-  <R extends $S.struct>() =>
+  <R extends $S.Struct>() =>
   <K extends keyof R, B>(
     k: K,
     f: (r: Pick<R, K>[K]) => RT.ReaderTask<Pick<R, K>, B>,
@@ -18,7 +18,7 @@ export const picks =
     picksW<R>()(k, f)
 
 export const picksW =
-  <R1 extends $S.struct>() =>
+  <R1 extends $S.Struct>() =>
   <K extends keyof R1, R2, B>(
     k: K,
     f: (r: Pick<R1, K>[K]) => RT.ReaderTask<R2, B>,
@@ -26,11 +26,11 @@ export const picksW =
     pipe(pick<R1>()(k), RT.chainW(f))
 
 export const picksIOK =
-  <R extends $S.struct>() =>
+  <R extends $S.Struct>() =>
   <K extends keyof R, B>(k: K, f: (r: Pick<R, K>[K]) => IO.IO<B>) =>
     picks<R>()(k, RT.fromIOK(f))
 
 export const picksTaskK =
-  <R extends $S.struct>() =>
+  <R extends $S.Struct>() =>
   <K extends keyof R, B>(k: K, f: (r: Pick<R, K>[K]) => T.Task<B>) =>
     picks<R>()(k, RT.fromTaskK(f))

--- a/src/ReaderTaskEither.ts
+++ b/src/ReaderTaskEither.ts
@@ -9,12 +9,12 @@ import * as TE from 'fp-ts/TaskEither'
 import * as $S from './struct'
 
 export const pick =
-  <R extends $S.struct>() =>
+  <R extends $S.Struct>() =>
   <K extends keyof R>(k: K) =>
     RTE.asks((r: Pick<R, K>) => r[k])
 
 export const picks =
-  <R extends $S.struct>() =>
+  <R extends $S.Struct>() =>
   <K extends keyof R, E, B>(
     k: K,
     f: (r: Pick<R, K>[K]) => RTE.ReaderTaskEither<Pick<R, K>, E, B>,
@@ -22,7 +22,7 @@ export const picks =
     picksW<R>()(k, f)
 
 export const picksW =
-  <R1 extends $S.struct>() =>
+  <R1 extends $S.Struct>() =>
   <K extends keyof R1, R2, E, B>(
     k: K,
     f: (r: Pick<R1, K>[K]) => RTE.ReaderTaskEither<R2, E, B>,
@@ -30,23 +30,23 @@ export const picksW =
     pipe(pick<R1>()(k), RTE.chainW(f))
 
 export const picksOptionK =
-  <R extends $S.struct>() =>
+  <R extends $S.Struct>() =>
   <E>(onNone: Lazy<E>) =>
   <K extends keyof R, B>(k: K, f: (r: Pick<R, K>[K]) => O.Option<B>) =>
     picks<R>()(k, RTE.fromOptionK(onNone)(f))
 
 export const picksEitherK =
-  <R extends $S.struct>() =>
+  <R extends $S.Struct>() =>
   <K extends keyof R, _E, B>(k: K, f: (r: Pick<R, K>[K]) => E.Either<_E, B>) =>
     picks<R>()(k, RTE.fromEitherK(f))
 
 export const picksIOK =
-  <R extends $S.struct>() =>
+  <R extends $S.Struct>() =>
   <K extends keyof R, B>(k: K, f: (r: Pick<R, K>[K]) => IO.IO<B>) =>
     pipe(pick<R>()(k), RTE.chainIOK(f))
 
 export const picksIOEitherK =
-  <R extends $S.struct>() =>
+  <R extends $S.Struct>() =>
   <K extends keyof R, _E, B>(
     k: K,
     f: (r: Pick<R, K>[K]) => IOE.IOEither<_E, B>,
@@ -54,12 +54,12 @@ export const picksIOEitherK =
     picks<R>()(k, RTE.fromIOEitherK(f))
 
 export const picksTaskK =
-  <R extends $S.struct>() =>
+  <R extends $S.Struct>() =>
   <K extends keyof R, B>(k: K, f: (r: Pick<R, K>[K]) => T.Task<B>) =>
     pipe(pick<R>()(k), RTE.chainTaskK(f))
 
 export const picksTaskEitherK =
-  <R extends $S.struct>() =>
+  <R extends $S.Struct>() =>
   <K extends keyof R, _E, B>(
     k: K,
     f: (r: Pick<R, K>[K]) => TE.TaskEither<_E, B>,

--- a/src/Type.ts
+++ b/src/Type.ts
@@ -40,7 +40,7 @@ export function literal(a: number | string | RegExp, name?: string) {
     : t.literal(a, name)
 }
 
-const isStruct = (u: unknown): u is $S.struct =>
+const isStruct = (u: unknown): u is $S.Struct =>
   'object' === typeof u && null !== u && !Array.isArray(u)
 
 export const struct = new t.Type(

--- a/src/struct.ts
+++ b/src/struct.ts
@@ -14,24 +14,24 @@ export type Struct = object
 // eslint-disable-next-line @typescript-eslint/ban-types
 export type struct = object
 
-export const toReadonlyArray = <A extends struct>(
+export const toReadonlyArray = <A extends Struct>(
   a: A,
 ): ReadonlyArray<Readonly<[keyof A, A[keyof A]]>> => RR.toReadonlyArray(a)
 
 export const lookup =
-  <S extends struct, K extends keyof S>(k: K) =>
+  <S extends Struct, K extends keyof S>(k: K) =>
   (s: S): S[K] =>
     s[k]
 
 export const modifyAt =
-  <S extends struct, K extends keyof S>(k: K, f: (a: S[K]) => S[K]) =>
+  <S extends Struct, K extends keyof S>(k: K, f: (a: S[K]) => S[K]) =>
   (s: S): S => ({ ...s, [k]: f(s[k]) })
 
-export const updateAt = <S extends struct, K extends keyof S>(k: K, a: S[K]) =>
+export const updateAt = <S extends Struct, K extends keyof S>(k: K, a: S[K]) =>
   modifyAt(k, () => a)
 
 export const filterDeep =
-  <A extends struct>(f: Predicate<unknown /*ValuesDeep<A>*/>) =>
+  <A extends Struct>(f: Predicate<unknown /*ValuesDeep<A>*/>) =>
   (a: A): PartialDeep<A> =>
     pipe(
       a,
@@ -57,14 +57,14 @@ export const filterDeep =
     )
 
 export const patch =
-  <A extends struct, B extends PartialDeep<A> & struct>(b: B) =>
+  <A extends Struct, B extends PartialDeep<A> & Struct>(b: B) =>
   (a: A): IntersectionDeep<A, B> =>
     pipe(
       b,
       toReadonlyArray,
       RA.map(([key, b]) =>
         $t.struct.is(b)
-          ? ([key, patch(b)(a[key as keyof A] as A[keyof A] & struct)] as const)
+          ? ([key, patch(b)(a[key as keyof A] as A[keyof A] & Struct)] as const)
           : ([key, b] as const),
       ),
       RA.reduce({} as IntersectionDeep<A, B>, (ab, [key, b]) => ({

--- a/src/struct.ts
+++ b/src/struct.ts
@@ -6,6 +6,11 @@ import { IntersectionDeep, PartialDeep } from '.'
 import { curry } from './function'
 import * as $t from './Type'
 
+export type Struct = object
+
+/**
+ * @deprecated Use `Struct` instead
+ */
 // eslint-disable-next-line @typescript-eslint/ban-types
 export type struct = object
 


### PR DESCRIPTION
`struct` is not a primitive type, as such it should be capitalized. This also removes the collision between the type and the module names.