### PR TITLE
Avoid to serialize values into JSON strings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -128,3 +128,6 @@ dist
 .yarn/build-state.yml
 .yarn/install-state.gz
 .pnp.*
+
+# IDE/Editor
+.idea/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,12 +10,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - Add `AggregateError` inspired from TC39.
 - Add `decode` method to `Type` module to help wrapping `io-ts` `Errors` into an `Error` subclass.
+- Add unit tests for the `set` function of the `Redis` module. 
 
 ### Changed
 
 - Replace `struct` type with `Struct`.
 - Rename `GeneratorL` module to `Yield`.
 - Use `cause` property to record wrapped errors (inspired by TC39).
+- Decode from Json and then from the given codec in the `get` function of the `Redis` module.
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - Add `AggregateError` inspired from TC39.
 - Add `decode` method to `Type` module to help wrapping `io-ts` `Errors` into an `Error` subclass.
-- Add unit tests for the `set` function of the `Redis` module. 
+- Add unit tests for the `set` function of the `Redis` module.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Added
 
-- Add `Struct` type.
+- Add `AggregateError` inspired from TC39.
+- Add `decode` method to `Type` module to help wrapping `io-ts` `Errors` into an `Error` subclass.
+
+### Changed
+
+- Replace `struct` type with `Struct`.
 - Rename `GeneratorL` module to `Yield`.
+- Use `cause` property to record wrapped errors (inspired by TC39).
 
 ### Deprecated
 

--- a/src/Cache.ts
+++ b/src/Cache.ts
@@ -12,7 +12,7 @@ import * as $R from './Random'
 export interface Cache {
   readonly get: <A>(
     key: string,
-    codec: t.Type<A, unknown>,
+    codec: t.Type<A, J.Json>,
   ) => TE.TaskEither<Error, A>
   readonly set: <A>(
     key: string,

--- a/src/Cache.ts
+++ b/src/Cache.ts
@@ -12,7 +12,7 @@ import * as $R from './Random'
 export interface Cache {
   readonly get: <A>(
     key: string,
-    codec: t.Type<A, J.Json>,
+    codec: t.Type<A, unknown>,
   ) => TE.TaskEither<Error, A>
   readonly set: <A>(
     key: string,

--- a/src/Error.test.ts
+++ b/src/Error.test.ts
@@ -1,5 +1,5 @@
 import { pipe } from 'fp-ts/function'
-import { fromUnknown } from './Error'
+import { fromUnknown, wrap } from './Error'
 
 describe('Error', () => {
   describe('fromUnknown', () => {
@@ -11,6 +11,14 @@ describe('Error', () => {
     })
     it('should discard other values and return default Error object', () => {
       expect(pipe(1138, fromUnknown(Error('bar'))).message).toBe('bar')
+    })
+  })
+
+  describe('wrap', () => {
+    test('wrapping a cause', () => {
+      expect(pipe(Error('foo'), wrap(Error('bar'))).cause).toStrictEqual(
+        Error('foo'),
+      )
     })
   })
 })

--- a/src/Type.test.ts
+++ b/src/Type.test.ts
@@ -1,8 +1,9 @@
 import * as E from 'fp-ts/Either'
 import { pipe } from 'fp-ts/function'
 import * as t from 'io-ts'
+import * as $Er from './Error'
 import * as $RA from './ReadonlyArray'
-import { alias, lax, literal, literalUnion, numeric } from './Type'
+import { alias, decode, lax, literal, literalUnion, numeric } from './Type'
 
 describe('Type', () => {
   describe('numeric', () => {
@@ -99,6 +100,23 @@ describe('Type', () => {
           ),
         ).toStrictEqual(output),
       )
+    })
+  })
+
+  describe('decode', () => {
+    test('decoding unsupported input', () => {
+      const result = decode(t.union([t.number, numeric]))('foo')
+      if (E.isRight(result)) {
+        throw new Error()
+      }
+
+      expect(result.left.message).toStrictEqual(
+        'Cannot decode input with codec "(number | Numeric)"',
+      )
+      expect(result.left).toBeInstanceOf($Er.AggregateError)
+      if (result.left instanceof $Er.AggregateError) {
+        expect(result.left.errors).toHaveLength(2)
+      }
     })
   })
 })

--- a/src/cache/Redis.test.ts
+++ b/src/cache/Redis.test.ts
@@ -13,7 +13,7 @@ describe('Cache', () => {
         const _redis = $redis(redis.createClient)
 
         await expect(
-          pipe(_redis.get('foo', t.any), T.map(E.isLeft))(),
+          pipe(_redis.get('foo', t.unknown), T.map(E.isLeft))(),
         ).resolves.toBe(true)
       })
       it('should fail with wrong item encoding', async () => {

--- a/src/cache/Redis.test.ts
+++ b/src/cache/Redis.test.ts
@@ -3,7 +3,6 @@ import { constVoid, pipe } from 'fp-ts/function'
 import * as T from 'fp-ts/Task'
 import * as TE from 'fp-ts/TaskEither'
 import * as t from 'io-ts'
-import { NumberFromString } from 'io-ts-types'
 import redis from 'redis-mock'
 import { $redis } from './Redis'
 
@@ -14,7 +13,7 @@ describe('Cache', () => {
         const _redis = $redis(redis.createClient)
 
         await expect(
-          pipe(_redis.get('foo', t.unknown), T.map(E.isLeft))(),
+          pipe(_redis.get('foo', t.any), T.map(E.isLeft))(),
         ).resolves.toBe(true)
       })
       it('should fail with wrong item encoding', async () => {
@@ -60,9 +59,9 @@ describe('Cache', () => {
         const result = await _redis.set('foo', t.number)(42)()
 
         expect(result).toStrictEqual(E.of(constVoid()))
-        await expect(
-          _redis.get('foo', NumberFromString)(),
-        ).resolves.toStrictEqual(E.of(42))
+        await expect(_redis.get('foo', t.number)()).resolves.toStrictEqual(
+          E.of(42),
+        )
       })
       it('should set object item properly', async () => {
         const _redis = $redis(redis.createClient)
@@ -71,8 +70,8 @@ describe('Cache', () => {
         const result = await _redis.set('foo', codec)({ foo: 'foo', bar: 42 })()
 
         expect(result).toStrictEqual(E.of(constVoid()))
-        await expect(_redis.get('foo', t.string)()).resolves.toStrictEqual(
-          E.of(JSON.stringify({ foo: 'foo', bar: 42 })),
+        await expect(_redis.get('foo', codec)()).resolves.toStrictEqual(
+          E.of({ foo: 'foo', bar: 42 }),
         )
       })
     })

--- a/src/cache/Redis.ts
+++ b/src/cache/Redis.ts
@@ -37,7 +37,8 @@ export const $redis = (redis: Lazy<RedisClient>, ttl = Infinity): $C.Cache => {
         ),
         TE.chainEitherK(
           flow(
-            JsonFromString.pipe(codec).decode,
+            JsonFromString.decode,
+            Ei.chain(codec.decode),
             Ei.mapLeft(
               $Er.fromUnknown(
                 Error(`Cannot decode cache item "${key}" into "${codec.name}"`),


### PR DESCRIPTION
The `set` method of the **Redis** module always serializes values into JSON strings, regardless the original type of the value. It works for `object` values but, especially for `string` values, produces an unexpected behavior which changes original value (i.e. `foo` --> `"foo"`).

Since Redis only accepts `string` values, keep JSON serialization for `object` value type and cast to `string` the others, returning responsibility of the type-check to the consumers of the client.