### PR TITLE
Pet error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Added
 
-- Add `Struct` type.
-- Rename `GeneratorL` module to `Yield`.
-- Add `AggregateError` from TC39.
+- Add `AggregateError` inspired from TC39.
 - Add `decode` method to `Type` module to help wrapping `io-ts` `Errors` into an `Error` subclass.
+
+### Changed
+
+- Replace `struct` type with `Struct`.
+- Rename `GeneratorL` module to `Yield`.
+- Use `cause` property to record wrapped errors (inspired by TC39).
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - Add `Struct` type.
 - Rename `GeneratorL` module to `Yield`.
+- Add `AggregateError` from TC39.
+- Add `decode` method to `Type` module to help wrapping `io-ts` `Errors` into an `Error` subclass.
 
 ### Deprecated
 

--- a/src/Error.test.ts
+++ b/src/Error.test.ts
@@ -1,5 +1,5 @@
 import { pipe } from 'fp-ts/function'
-import { fromUnknown } from './Error'
+import { fromUnknown, wrap } from './Error'
 
 describe('Error', () => {
   describe('fromUnknown', () => {
@@ -11,6 +11,14 @@ describe('Error', () => {
     })
     it('should discard other values and return default Error object', () => {
       expect(pipe(1138, fromUnknown(Error('bar'))).message).toBe('bar')
+    })
+  })
+
+  describe('wrap', () => {
+    test('wrapping a cause', () => {
+      expect(pipe(Error('foo'), wrap(Error('bar'))).cause).toStrictEqual(
+        Error('foo'),
+      )
     })
   })
 })

--- a/src/Error.ts
+++ b/src/Error.ts
@@ -47,20 +47,25 @@ export const fromUnknown = (e: Error) =>
     O.getOrElse(() => e),
   )
 
-const withPrev = (prev: Error) => (error: Error) => {
-  ;(error as any).prev = prev
+/**
+ * @see https://tc39.es/proposal-error-cause/
+ */
+const withCause = (cause: Error) => (error: Error) => {
+  ;(error as any).cause = cause
+  // TODO: remove on 0.2.0.
+  ;(error as any).prev = cause
 
   return error
 }
 
 export const wrap =
   (e: Error) =>
-  (u: unknown): Error & { readonly prev?: Error } =>
+  (u: unknown): Error & { readonly cause?: Error } =>
     pipe(
       u,
       _fromUnknown,
       O.match(
         () => e,
-        (error) => withPrev(error)(e),
+        (error) => withCause(error)(e),
       ),
     )

--- a/src/Error.ts
+++ b/src/Error.ts
@@ -4,6 +4,15 @@ import * as t from 'io-ts'
 import { failure } from 'io-ts/PathReporter'
 import * as $S from './struct'
 
+/**
+ * @see https://tc39.es/proposal-promise-any/#sec-aggregate-error-objects
+ */
+export class AggregateError extends Error {
+  constructor(readonly errors: ReadonlyArray<Error>, message?: string) {
+    super(message)
+  }
+}
+
 const is = (u: unknown): u is Error =>
   t
     .intersection([

--- a/src/Error.ts
+++ b/src/Error.ts
@@ -25,7 +25,7 @@ export const ErrorC = new t.Type(
   'Error',
   is,
   (u, c) => (is(u) ? t.success(u) : t.failure(u, c)),
-  $S.lookup('message'),
+  (o) => pipe(o, $S.lookup('message')),
 )
 
 const _fromUnknown = (u: unknown) => {

--- a/src/Type.test.ts
+++ b/src/Type.test.ts
@@ -1,8 +1,9 @@
 import * as E from 'fp-ts/Either'
 import { pipe } from 'fp-ts/function'
 import * as t from 'io-ts'
+import * as $Er from './Error'
 import * as $RA from './ReadonlyArray'
-import { alias, lax, literal, literalUnion, numeric } from './Type'
+import { alias, decode, lax, literal, literalUnion, numeric } from './Type'
 
 describe('Type', () => {
   describe('numeric', () => {
@@ -99,6 +100,23 @@ describe('Type', () => {
           ),
         ).toStrictEqual(output),
       )
+    })
+  })
+
+  describe('decode', () => {
+    test('decoding unsupported input', () => {
+      const result = decode(t.union([t.number, numeric]))('foo')
+      if (E.isRight(result)) {
+        throw new Error()
+      }
+
+      expect(result.left.message).toStrictEqual(
+        'Cannot decode input with codec "(number | Numeric)"',
+      )
+      expect(result.left).toBeInstanceOf($Er.AggregateError)
+      if (result.left instanceof $Er.AggregateError) {
+        expect(result.left.errors).toHaveLength(2)
+      }
     })
   })
 })


### PR DESCRIPTION
### `AggregateError`

`io-ts` fails with an array of errors, which is not as easy to handle as a simple `Error`. Let's use TC39 proposal for `AggregateError` to help with this issue.

### Error Cause

Instead of using a generic `prev` property for wrapped errors, we can default to the TC39ish `cause`.