### PR TITLE
Enhance dependency management

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Add `decode` method to `Type` module to help wrapping `io-ts` `Errors` into an `Error` subclass.
 - Add unit tests for the `set` function of the `Redis` module.
 - Add `Has` module and enhance `ReaderTaskEither` for smart dependencies management (inspired by [Effect-TS](https://www.matechs.com/open-source)):
+
   ```typescript
   // Foo.ts
   import { TaskEither } from 'fp-ts/TaskEither'
@@ -24,9 +25,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
   export const TagFoo = $has.tag<Foo>()
 
   export const $foo = {
-    bar: $readerTaskEither.derivesTaskEither(TagFoo, 'bar')
+    bar: $readerTaskEither.derivesTaskEither(TagFoo, 'bar'),
   }
   ```
+
   ```typescript
   // Bar.ts
   import { IOEither } from 'fp-ts/IOEither'
@@ -40,6 +42,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
   export const bar = $readerTaskEither.deriveIOEither(TagBar)
   ```
+
   ```typescript
   // index.ts
   import { $has } from 'fortepiano'
@@ -49,18 +52,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
   import { $foo, TagFoo } from './Foo'
 
   // const a: ReaderTaskEither<Has<Foo> & Has<Bar>, Error, boolean>
-  const a = pipe(
-    $foo.bar(42),
-    readerTaskEither.chainW(bar)
-  )
+  const a = pipe($foo.bar(42), readerTaskEither.chainW(bar))
 
   // const b: TaskEither<Error, boolean>
   const b = a(
     // Let's mock our dependencies.
     pipe(
-      $has.singleton(TagFoo, { bar: () => taskEither.of('foobar')}),
-      $has.upsertAt(TagBar, () => ioEither.of(true))
-    )
+      $has.singleton(TagFoo, { bar: () => taskEither.of('foobar') }),
+      $has.upsertAt(TagBar, () => ioEither.of(true)),
+    ),
   )
   ```
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,24 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Add `AggregateError` inspired from TC39.
 - Add `decode` method to `Type` module to help wrapping `io-ts` `Errors` into an `Error` subclass.
 - Add unit tests for the `set` function of the `Redis` module.
+- Add `Has` module and enhance `ReaderTaskEither` for smart dependencies management (inspired by [Effect-TS](https://www.matechs.com/open-source)):
+  ```typescript
+  import { TaskEither } from 'fp-ts/TaskEither'
+  import { $has, $readerTaskEither } from 'fortepiano'
+
+  export interface Foo {
+    bar(a: number): TaskEither<Error, string>
+  }
+
+  export const TagFoo = $has.tag<Foo>()
+
+  export const $foo = {
+    bar: $readerTaskEither.derivesTaskEither(TagFoo, 'bar')
+  }
+
+  // const a: ReaderTaskEither<Has<Foo>, Error, string>
+  const a = $foo.bar(42)
+  ```
 
 ### Changed
 

--- a/src/Has.test.ts
+++ b/src/Has.test.ts
@@ -1,0 +1,58 @@
+import { pipe } from 'fp-ts/function'
+import { lookup, modifyAt, singleton, tag, upsertAt } from './Has'
+
+describe('Has', () => {
+  describe('tag', () => {
+    test('creating unique tags', () => {
+      expect(tag<number>().key).not.toStrictEqual(tag<number>().key)
+    })
+  })
+
+  describe('singleton', () => {
+    test('creating Has with single value', () => {
+      const _tag = tag<number>()
+
+      expect(singleton(_tag, 42)).toStrictEqual({ [_tag.key]: 42 })
+    })
+  })
+
+  describe('lookup', () => {
+    test('retrieving value', () => {
+      const _tag = tag<number>()
+
+      expect(pipe(singleton(_tag, 42), lookup(_tag))).toStrictEqual(42)
+    })
+  })
+
+  describe('upsertAt', () => {
+    test('adding value', () => {
+      const fooTag = tag<number>()
+      const barTag = tag<string>()
+      const has = pipe(singleton(fooTag, 42), upsertAt(barTag, 'foobar'))
+
+      expect(pipe(has, lookup(fooTag))).toStrictEqual(42)
+      expect(pipe(has, lookup(barTag))).toStrictEqual('foobar')
+    })
+    test('replacing value', () => {
+      const _tag = tag<number>()
+
+      expect(
+        pipe(singleton(_tag, 42), upsertAt(_tag, 1138), lookup(_tag)),
+      ).toStrictEqual(1138)
+    })
+  })
+
+  describe('modifyAt', () => {
+    test('modifying value', () => {
+      const _tag = tag<number>()
+
+      expect(
+        pipe(
+          singleton(_tag, 42),
+          modifyAt(_tag, (n) => n * 2),
+          lookup(_tag),
+        ),
+      ).toStrictEqual(42 * 2)
+    })
+  })
+})

--- a/src/Has.ts
+++ b/src/Has.ts
@@ -1,0 +1,33 @@
+declare const HasURI: unique symbol
+export interface Has<A> {
+  readonly URI: typeof HasURI
+  readonly [K: symbol]: A
+}
+
+declare const TagURI: unique symbol
+export interface Tag<A> {
+  readonly [TagURI]: A
+  readonly key: symbol
+}
+
+export const tag = <A>(): Tag<A> => ({ key: Symbol() } as Tag<A>)
+
+export const singleton = <A>(tag: Tag<A>, a: A): Has<A> =>
+  ({ [tag.key]: a } as Has<A>)
+
+export const lookup =
+  <A>(tag: Tag<A>) =>
+  (has: Has<A>) =>
+    has[tag.key]
+
+export const upsertAt =
+  <B>(tag: Tag<B>, b: B) =>
+  <_Has extends Has<unknown>>(has: _Has): _Has & Has<B> => ({
+    ...has,
+    ...singleton(tag, b),
+  })
+
+export const modifyAt =
+  <B>(tag: Tag<B>, f: (b: B) => B) =>
+  <_Has extends Has<B>>(has: _Has) =>
+    upsertAt(tag, f(lookup(tag)(has)))(has)

--- a/src/ReaderTaskEither.test.ts
+++ b/src/ReaderTaskEither.test.ts
@@ -34,6 +34,7 @@ import {
   deriveTask,
   deriveTaskEither,
   pick,
+  picks,
   picksEitherK,
   picksIOEitherK,
   picksIOK,
@@ -80,6 +81,31 @@ describe('ReaderTaskEither', () => {
       await expect(pick<R>()('bar')({ bar: 1138 })()).resolves.toStrictEqual(
         E.right(1138),
       )
+    })
+  })
+
+  describe('picks', () => {
+    it('should return a computation on part of the context', async () => {
+      interface R {
+        http: {
+          host: string
+          fetch: (
+            id: number,
+          ) => RTE.ReaderTaskEither<Pick<R, 'http'>, Error, string>
+        }
+      }
+
+      const fetch: R['http']['fetch'] =
+        (id) =>
+        ({ http }) =>
+        async () =>
+          E.right(`${http.host}/${id}`)
+
+      await expect(
+        picks<R>()('http', ({ fetch }) => fetch(42))({
+          http: { host: 'foobar', fetch },
+        })(),
+      ).resolves.toStrictEqual(E.right('foobar/42'))
     })
   })
 

--- a/src/ReaderTaskEither.test.ts
+++ b/src/ReaderTaskEither.test.ts
@@ -1,11 +1,38 @@
 import * as E from 'fp-ts/Either'
+import { pipe } from 'fp-ts/function'
 import * as IO from 'fp-ts/IO'
 import * as IOE from 'fp-ts/IOEither'
 import * as O from 'fp-ts/Option'
+import * as R from 'fp-ts/Reader'
+import * as RE from 'fp-ts/ReaderEither'
+import * as RT from 'fp-ts/ReaderTask'
 import * as RTE from 'fp-ts/ReaderTaskEither'
 import * as T from 'fp-ts/Task'
 import * as TE from 'fp-ts/TaskEither'
+import * as $H from './Has'
 import {
+  derive,
+  deriveEither,
+  deriveIO,
+  deriveIOEither,
+  deriveOption,
+  deriveReader,
+  deriveReaderEither,
+  deriveReaderTask,
+  deriveReaderTaskEither,
+  derives,
+  derivesEither,
+  derivesIO,
+  derivesIOEither,
+  derivesOption,
+  derivesReader,
+  derivesReaderEither,
+  derivesReaderTask,
+  derivesReaderTaskEither,
+  derivesTask,
+  derivesTaskEither,
+  deriveTask,
+  deriveTaskEither,
   pick,
   picksEitherK,
   picksIOEitherK,
@@ -14,7 +41,30 @@ import {
   picksTaskEitherK,
   picksTaskK,
   picksW,
+  read,
+  readEither,
+  readIO,
+  readIOEither,
+  readOption,
+  readReader,
+  readReaderEither,
+  readReaderTask,
+  readReaderTaskEither,
+  reads,
+  readsEither,
+  readsIO,
+  readsIOEither,
+  readsOption,
+  readsReader,
+  readsReaderEither,
+  readsReaderTask,
+  readsReaderTaskEither,
+  readsTask,
+  readsTaskEither,
+  readTask,
+  readTaskEither,
 } from './ReaderTaskEither'
+import * as $S from './struct'
 
 describe('ReaderTaskEither', () => {
   describe('pick', () => {
@@ -150,6 +200,507 @@ describe('ReaderTaskEither', () => {
       await expect(
         picksTaskEitherK<R>()('fetch', (fetch) => fetch(42))({ fetch })(),
       ).resolves.toStrictEqual(E.right('42'))
+    })
+  })
+
+  describe('read', () => {
+    test('retrieving a slice of the environment', async () => {
+      const tag = $H.tag<number>()
+
+      await expect(read(tag)($H.singleton(tag, 42))()).resolves.toStrictEqual(
+        E.right(42),
+      )
+    })
+  })
+
+  describe('readOption', () => {
+    test('retrieving a slice of the environment', async () => {
+      const tag = $H.tag<O.Option<number>>()
+
+      await expect(
+        readOption(tag)(Error)($H.singleton(tag, O.some(42)))(),
+      ).resolves.toStrictEqual(E.right(42))
+    })
+  })
+
+  describe('readEither', () => {
+    test('retrieving a slice of the environment', async () => {
+      const tag = $H.tag<E.Either<Error, number>>()
+
+      await expect(
+        readEither(tag)($H.singleton(tag, E.right(42)))(),
+      ).resolves.toStrictEqual(E.right(42))
+    })
+  })
+
+  describe('readIO', () => {
+    test('retrieving a slice of the environment', async () => {
+      const tag = $H.tag<IO.IO<number>>()
+
+      await expect(
+        readIO(tag)($H.singleton(tag, IO.of(42)))(),
+      ).resolves.toStrictEqual(E.right(42))
+    })
+  })
+
+  describe('readIOEither', () => {
+    test('retrieving a slice of the environment', async () => {
+      const tag = $H.tag<IOE.IOEither<Error, number>>()
+
+      await expect(
+        readIOEither(tag)($H.singleton(tag, IOE.right(42)))(),
+      ).resolves.toStrictEqual(E.right(42))
+    })
+  })
+
+  describe('readTask', () => {
+    test('retrieving a slice of the environment', async () => {
+      const tag = $H.tag<T.Task<number>>()
+
+      await expect(
+        readTask(tag)($H.singleton(tag, T.of(42)))(),
+      ).resolves.toStrictEqual(E.right(42))
+    })
+  })
+
+  describe('readTaskEither', () => {
+    test('retrieving a slice of the environment', async () => {
+      const tag = $H.tag<TE.TaskEither<Error, number>>()
+
+      await expect(
+        readTaskEither(tag)($H.singleton(tag, TE.right(42)))(),
+      ).resolves.toStrictEqual(E.right(42))
+    })
+  })
+
+  describe('readReader', () => {
+    test('retrieving a slice of the environment', async () => {
+      const tag = $H.tag<R.Reader<$S.Struct, number>>()
+
+      await expect(
+        readReader(tag)($H.singleton(tag, R.of(42)))(),
+      ).resolves.toStrictEqual(E.right(42))
+    })
+  })
+
+  describe('readReaderEither', () => {
+    test('retrieving a slice of the environment', async () => {
+      const tag = $H.tag<RE.ReaderEither<$S.Struct, Error, number>>()
+
+      await expect(
+        readReaderEither(tag)($H.singleton(tag, RE.right(42)))(),
+      ).resolves.toStrictEqual(E.right(42))
+    })
+  })
+
+  describe('readReaderTask', () => {
+    test('retrieving a slice of the environment', async () => {
+      const tag = $H.tag<RT.ReaderTask<$S.Struct, number>>()
+
+      await expect(
+        readReaderTask(tag)($H.singleton(tag, RT.of(42)))(),
+      ).resolves.toStrictEqual(E.right(42))
+    })
+  })
+
+  describe('readReaderTaskEither', () => {
+    test('retrieving a slice of the environment', async () => {
+      const tag = $H.tag<RTE.ReaderTaskEither<$S.Struct, Error, number>>()
+
+      await expect(
+        readReaderTaskEither(tag)($H.singleton(tag, RTE.right(42)))(),
+      ).resolves.toStrictEqual(E.right(42))
+    })
+  })
+
+  describe('reads', () => {
+    test('retrieving part of a slice of the environment', async () => {
+      const tag = $H.tag<{ foo: number }>()
+
+      await expect(
+        reads(tag, 'foo')($H.singleton(tag, { foo: 42 }))(),
+      ).resolves.toStrictEqual(E.right(42))
+    })
+    test('retrieving a function bound to its parent object', async () => {
+      const tag = $H.tag<{ foo: number; bar(): number }>()
+
+      await expect(
+        pipe(
+          reads(tag, 'bar'),
+          RTE.map((f) => f()),
+        )(
+          $H.singleton(tag, {
+            foo: 42,
+            bar() {
+              return this.foo
+            },
+          }),
+        )(),
+      ).resolves.toStrictEqual(E.right(42))
+    })
+  })
+
+  describe('readsOption', () => {
+    test('retrieving part of a slice of the environment', async () => {
+      const tag = $H.tag<{ foo: O.Option<number> }>()
+
+      await expect(
+        readsOption(tag, 'foo')(Error)(
+          $H.singleton(tag, { foo: O.some(42) }),
+        )(),
+      ).resolves.toStrictEqual(E.right(42))
+    })
+  })
+
+  describe('readsEither', () => {
+    test('retrieving part of a slice of the environment', async () => {
+      const tag = $H.tag<{ foo: E.Either<Error, number> }>()
+
+      await expect(
+        readsEither(tag, 'foo')($H.singleton(tag, { foo: E.right(42) }))(),
+      ).resolves.toStrictEqual(E.right(42))
+    })
+  })
+
+  describe('readsIO', () => {
+    test('retrieving part of a slice of the environment', async () => {
+      const tag = $H.tag<{ foo: IO.IO<number> }>()
+
+      await expect(
+        readsIO(tag, 'foo')($H.singleton(tag, { foo: IO.of(42) }))(),
+      ).resolves.toStrictEqual(E.right(42))
+    })
+  })
+
+  describe('readsIOEither', () => {
+    test('retrieving part of a slice of the environment', async () => {
+      const tag = $H.tag<{ foo: IOE.IOEither<Error, number> }>()
+
+      await expect(
+        readsIOEither(tag, 'foo')($H.singleton(tag, { foo: IOE.right(42) }))(),
+      ).resolves.toStrictEqual(E.right(42))
+    })
+  })
+
+  describe('readsTask', () => {
+    test('retrieving part of a slice of the environment', async () => {
+      const tag = $H.tag<{ foo: T.Task<number> }>()
+
+      await expect(
+        readsTask(tag, 'foo')($H.singleton(tag, { foo: T.of(42) }))(),
+      ).resolves.toStrictEqual(E.right(42))
+    })
+  })
+
+  describe('readsTaskEither', () => {
+    test('retrieving part of a slice of the environment', async () => {
+      const tag = $H.tag<{ foo: TE.TaskEither<Error, number> }>()
+
+      await expect(
+        readsTaskEither(tag, 'foo')($H.singleton(tag, { foo: TE.right(42) }))(),
+      ).resolves.toStrictEqual(E.right(42))
+    })
+  })
+
+  describe('readsReader', () => {
+    test('retrieving part of a slice of the environment', async () => {
+      const tag = $H.tag<{ foo: R.Reader<$S.Struct, number> }>()
+
+      await expect(
+        readsReader(tag, 'foo')($H.singleton(tag, { foo: R.of(42) }))(),
+      ).resolves.toStrictEqual(E.right(42))
+    })
+  })
+
+  describe('readsReaderEither', () => {
+    test('retrieving part of a slice of the environment', async () => {
+      const tag = $H.tag<{ foo: RE.ReaderEither<$S.Struct, Error, number> }>()
+
+      await expect(
+        readsReaderEither(
+          tag,
+          'foo',
+        )($H.singleton(tag, { foo: RE.right(42) }))(),
+      ).resolves.toStrictEqual(E.right(42))
+    })
+  })
+
+  describe('readsReaderTask', () => {
+    test('retrieving part of a slice of the environment', async () => {
+      const tag = $H.tag<{ foo: RT.ReaderTask<$S.Struct, number> }>()
+
+      await expect(
+        readsReaderTask(tag, 'foo')($H.singleton(tag, { foo: RT.of(42) }))(),
+      ).resolves.toStrictEqual(E.right(42))
+    })
+  })
+
+  describe('readsReaderTaskEither', () => {
+    test('retrieving part of a slice of the environment', async () => {
+      const tag = $H.tag<{
+        foo: RTE.ReaderTaskEither<$S.Struct, Error, number>
+      }>()
+
+      await expect(
+        readsReaderTaskEither(
+          tag,
+          'foo',
+        )($H.singleton(tag, { foo: RTE.right(42) }))(),
+      ).resolves.toStrictEqual(E.right(42))
+    })
+  })
+
+  describe('derive', () => {
+    test('deriving a function from a slice of the environment', async () => {
+      const tag = $H.tag<() => number>()
+
+      await expect(
+        derive(tag)()($H.singleton(tag, () => 42))(),
+      ).resolves.toStrictEqual(E.right(42))
+    })
+  })
+
+  describe('deriveOption', () => {
+    test('deriving a function from a slice of the environment', async () => {
+      const tag = $H.tag<() => O.Option<number>>()
+
+      await expect(
+        deriveOption(tag)(Error)()($H.singleton(tag, () => O.some(42)))(),
+      ).resolves.toStrictEqual(E.right(42))
+    })
+  })
+
+  describe('deriveEither', () => {
+    test('deriving a function from a slice of the environment', async () => {
+      const tag = $H.tag<() => E.Either<Error, number>>()
+
+      await expect(
+        deriveEither(tag)()($H.singleton(tag, () => E.right(42)))(),
+      ).resolves.toStrictEqual(E.right(42))
+    })
+  })
+
+  describe('deriveIO', () => {
+    test('deriving a function from a slice of the environment', async () => {
+      const tag = $H.tag<() => IO.IO<number>>()
+
+      await expect(
+        deriveIO(tag)()($H.singleton(tag, () => IO.of(42)))(),
+      ).resolves.toStrictEqual(E.right(42))
+    })
+  })
+
+  describe('deriveIOEither', () => {
+    test('deriving a function from a slice of the environment', async () => {
+      const tag = $H.tag<() => IOE.IOEither<Error, number>>()
+
+      await expect(
+        deriveIOEither(tag)()($H.singleton(tag, () => IOE.right(42)))(),
+      ).resolves.toStrictEqual(E.right(42))
+    })
+  })
+
+  describe('deriveTask', () => {
+    test('deriving a function from a slice of the environment', async () => {
+      const tag = $H.tag<() => T.Task<number>>()
+
+      await expect(
+        deriveTask(tag)()($H.singleton(tag, () => T.of(42)))(),
+      ).resolves.toStrictEqual(E.right(42))
+    })
+  })
+
+  describe('deriveTaskEither', () => {
+    test('deriving a function from a slice of the environment', async () => {
+      const tag = $H.tag<() => TE.TaskEither<Error, number>>()
+
+      await expect(
+        deriveTaskEither(tag)()($H.singleton(tag, () => TE.right(42)))(),
+      ).resolves.toStrictEqual(E.right(42))
+    })
+  })
+
+  describe('deriveReader', () => {
+    test('deriving a function from a slice of the environment', async () => {
+      const tag = $H.tag<() => R.Reader<$S.Struct, number>>()
+
+      await expect(
+        deriveReader(tag)()($H.singleton(tag, () => R.of(42)))(),
+      ).resolves.toStrictEqual(E.right(42))
+    })
+  })
+
+  describe('deriveReaderEither', () => {
+    test('deriving a function from a slice of the environment', async () => {
+      const tag = $H.tag<() => RE.ReaderEither<$S.Struct, Error, number>>()
+
+      await expect(
+        deriveReaderEither(tag)()($H.singleton(tag, () => RE.right(42)))(),
+      ).resolves.toStrictEqual(E.right(42))
+    })
+  })
+
+  describe('deriveReaderTask', () => {
+    test('deriving a function from a slice of the environment', async () => {
+      const tag = $H.tag<() => RT.ReaderTask<$S.Struct, number>>()
+
+      await expect(
+        deriveReaderTask(tag)()($H.singleton(tag, () => RT.of(42)))(),
+      ).resolves.toStrictEqual(E.right(42))
+    })
+  })
+
+  describe('deriveReaderTaskEither', () => {
+    test('deriving a function from a slice of the environment', async () => {
+      const tag = $H.tag<() => RTE.ReaderTaskEither<$S.Struct, Error, number>>()
+
+      await expect(
+        deriveReaderTaskEither(tag)()($H.singleton(tag, () => RTE.right(42)))(),
+      ).resolves.toStrictEqual(E.right(42))
+    })
+  })
+
+  describe('derives', () => {
+    test('deriving a function from part of a slice of the environment', async () => {
+      const tag = $H.tag<{ foo: () => number }>()
+
+      await expect(
+        derives(tag, 'foo')()($H.singleton(tag, { foo: () => 42 }))(),
+      ).resolves.toStrictEqual(E.right(42))
+    })
+    test('deriving a function bound to its parent object', async () => {
+      const tag = $H.tag<{ foo: number; bar(): number }>()
+
+      await expect(
+        derives(tag, 'bar')()(
+          $H.singleton(tag, {
+            foo: 42,
+            bar() {
+              return this.foo
+            },
+          }),
+        )(),
+      ).resolves.toStrictEqual(E.right(42))
+    })
+  })
+
+  describe('derivesOption', () => {
+    test('deriving a function from a slice of the environment', async () => {
+      const tag = $H.tag<{ foo: () => O.Option<number> }>()
+
+      await expect(
+        derivesOption(tag, 'foo')(Error)()(
+          $H.singleton(tag, { foo: () => O.some(42) }),
+        )(),
+      ).resolves.toStrictEqual(E.right(42))
+    })
+  })
+
+  describe('derivesEither', () => {
+    test('deriving a function from a slice of the environment', async () => {
+      const tag = $H.tag<{ foo: () => E.Either<Error, number> }>()
+
+      await expect(
+        derivesEither(tag, 'foo')()(
+          $H.singleton(tag, { foo: () => E.right(42) }),
+        )(),
+      ).resolves.toStrictEqual(E.right(42))
+    })
+  })
+
+  describe('derivesIO', () => {
+    test('deriving a function from a slice of the environment', async () => {
+      const tag = $H.tag<{ foo: () => IO.IO<number> }>()
+
+      await expect(
+        derivesIO(tag, 'foo')()($H.singleton(tag, { foo: () => IO.of(42) }))(),
+      ).resolves.toStrictEqual(E.right(42))
+    })
+  })
+
+  describe('derivesIOEither', () => {
+    test('deriving a function from a slice of the environment', async () => {
+      const tag = $H.tag<{ foo: () => IOE.IOEither<Error, number> }>()
+
+      await expect(
+        derivesIOEither(tag, 'foo')()(
+          $H.singleton(tag, { foo: () => IOE.right(42) }),
+        )(),
+      ).resolves.toStrictEqual(E.right(42))
+    })
+  })
+
+  describe('derivesTask', () => {
+    test('deriving a function from a slice of the environment', async () => {
+      const tag = $H.tag<{ foo: () => T.Task<number> }>()
+
+      await expect(
+        derivesTask(tag, 'foo')()($H.singleton(tag, { foo: () => T.of(42) }))(),
+      ).resolves.toStrictEqual(E.right(42))
+    })
+  })
+
+  describe('derivesTaskEither', () => {
+    test('deriving a function from a slice of the environment', async () => {
+      const tag = $H.tag<{ foo: () => TE.TaskEither<Error, number> }>()
+
+      await expect(
+        derivesTaskEither(tag, 'foo')()(
+          $H.singleton(tag, { foo: () => TE.right(42) }),
+        )(),
+      ).resolves.toStrictEqual(E.right(42))
+    })
+  })
+
+  describe('derivesReader', () => {
+    test('deriving a function from a slice of the environment', async () => {
+      const tag = $H.tag<{ foo: () => R.Reader<$S.Struct, number> }>()
+
+      await expect(
+        derivesReader(tag, 'foo')()(
+          $H.singleton(tag, { foo: () => R.of(42) }),
+        )(),
+      ).resolves.toStrictEqual(E.right(42))
+    })
+  })
+
+  describe('derivesReaderEither', () => {
+    test('deriving a function from a slice of the environment', async () => {
+      const tag = $H.tag<{
+        foo: () => RE.ReaderEither<$S.Struct, Error, number>
+      }>()
+
+      await expect(
+        derivesReaderEither(tag, 'foo')()(
+          $H.singleton(tag, { foo: () => RE.right(42) }),
+        )(),
+      ).resolves.toStrictEqual(E.right(42))
+    })
+  })
+
+  describe('derivesReaderTask', () => {
+    test('deriving a function from a slice of the environment', async () => {
+      const tag = $H.tag<{ foo: () => RT.ReaderTask<$S.Struct, number> }>()
+
+      await expect(
+        derivesReaderTask(tag, 'foo')()(
+          $H.singleton(tag, { foo: () => RT.of(42) }),
+        )(),
+      ).resolves.toStrictEqual(E.right(42))
+    })
+  })
+
+  describe('derivesReaderTaskEither', () => {
+    test('deriving a function from a slice of the environment', async () => {
+      const tag = $H.tag<{
+        foo: () => RTE.ReaderTaskEither<$S.Struct, Error, number>
+      }>()
+
+      await expect(
+        derivesReaderTaskEither(tag, 'foo')()(
+          $H.singleton(tag, { foo: () => RTE.right(42) }),
+        )(),
+      ).resolves.toStrictEqual(E.right(42))
     })
   })
 })

--- a/src/ReaderTaskEither.ts
+++ b/src/ReaderTaskEither.ts
@@ -1,11 +1,16 @@
 import * as E from 'fp-ts/Either'
-import { Lazy, pipe } from 'fp-ts/function'
+import { identity, Lazy, pipe } from 'fp-ts/function'
 import * as IO from 'fp-ts/IO'
 import * as IOE from 'fp-ts/IOEither'
 import * as O from 'fp-ts/Option'
+import * as R from 'fp-ts/Reader'
+import * as RE from 'fp-ts/ReaderEither'
+import * as RT from 'fp-ts/ReaderTask'
 import * as RTE from 'fp-ts/ReaderTaskEither'
 import * as T from 'fp-ts/Task'
 import * as TE from 'fp-ts/TaskEither'
+import { ValueOf } from '.'
+import * as $H from './Has'
 import * as $S from './struct'
 
 export const pick =
@@ -65,3 +70,624 @@ export const picksTaskEitherK =
     f: (r: Pick<R, K>[K]) => TE.TaskEither<_E, B>,
   ) =>
     picks<R>()(k, RTE.fromTaskEitherK(f))
+
+export const read = <A>(tag: $H.Tag<A>) =>
+  pipe(
+    RTE.ask<$H.Has<A>>(),
+    RTE.map((r) => r[tag.key]),
+  )
+
+export const readOption =
+  <A>(tag: $H.Tag<O.Option<A>>) =>
+  <E>(onNone: Lazy<E>) =>
+    pipe(read(tag), RTE.chainOptionK(onNone)(identity))
+
+export const readEither = <E, A>(tag: $H.Tag<E.Either<E, A>>) =>
+  pipe(read(tag), RTE.chainEitherKW(identity))
+
+export const readIO = <A>(tag: $H.Tag<IO.IO<A>>) =>
+  pipe(read(tag), RTE.chainIOK(identity))
+
+export const readIOEither = <E, A>(tag: $H.Tag<IOE.IOEither<E, A>>) =>
+  pipe(read(tag), RTE.chainIOEitherKW(identity))
+
+export const readTask = <A>(tag: $H.Tag<T.Task<A>>) =>
+  pipe(read(tag), RTE.chainTaskK(identity))
+
+export const readTaskEither = <E, A>(tag: $H.Tag<TE.TaskEither<E, A>>) =>
+  pipe(read(tag), RTE.chainTaskEitherKW(identity))
+
+export const readReader = <R, A>(tag: $H.Tag<R.Reader<R, A>>) =>
+  pipe(read(tag), RTE.chainReaderKW(identity))
+
+export const readReaderEither = <R, E, A>(
+  tag: $H.Tag<RE.ReaderEither<R, E, A>>,
+) => pipe(read(tag), RTE.chainReaderEitherKW(identity))
+
+export const readReaderTask = <R, A>(tag: $H.Tag<RT.ReaderTask<R, A>>) =>
+  pipe(read(tag), RTE.chainReaderTaskKW(identity))
+
+export const readReaderTaskEither = <R, E, A>(
+  tag: $H.Tag<RTE.ReaderTaskEither<R, E, A>>,
+) => pipe(read(tag), RTE.flattenW)
+
+export const reads = <A extends $S.Struct, K extends keyof A>(
+  tag: $H.Tag<A>,
+  key: K,
+) =>
+  pipe(
+    read(tag),
+    RTE.map((a) => {
+      const prop = a[key]
+
+      return prop instanceof Function ? (prop.bind(a) as typeof prop) : prop
+    }),
+  )
+
+export const readsOption =
+  <
+    A extends $S.Struct,
+    K extends ValueOf<{
+      [K in keyof A]: A[K] extends O.Option<unknown> ? K : never
+    }>,
+  >(
+    tag: $H.Tag<A>,
+    key: K,
+  ) =>
+  <E>(
+    onNone: Lazy<E>,
+  ): A[K] extends O.Option<infer B>
+    ? RTE.ReaderTaskEither<$H.Has<A>, E, B>
+    : never =>
+    pipe(
+      read(tag),
+      RTE.chainOptionK(onNone)((a) => a[key] as any),
+    ) as any
+
+export const readsEither = <
+  A extends $S.Struct,
+  K extends ValueOf<{
+    [K in keyof A]: A[K] extends E.Either<unknown, unknown> ? K : never
+  }>,
+>(
+  tag: $H.Tag<A>,
+  key: K,
+): A[K] extends E.Either<infer E, infer B>
+  ? RTE.ReaderTaskEither<$H.Has<A>, E, B>
+  : never =>
+  pipe(
+    read(tag),
+    RTE.chainEitherKW((a) => a[key] as any),
+  ) as any
+
+export const readsIO = <
+  A extends $S.Struct,
+  K extends ValueOf<{
+    [K in keyof A]: A[K] extends IO.IO<unknown> ? K : never
+  }>,
+>(
+  tag: $H.Tag<A>,
+  key: K,
+): A[K] extends IO.IO<infer B>
+  ? RTE.ReaderTaskEither<$H.Has<A>, never, B>
+  : never =>
+  pipe(
+    read(tag),
+    RTE.chainIOK((a) => a[key] as any),
+  ) as any
+
+export const readsIOEither = <
+  A extends $S.Struct,
+  K extends ValueOf<{
+    [K in keyof A]: A[K] extends IOE.IOEither<unknown, unknown> ? K : never
+  }>,
+>(
+  tag: $H.Tag<A>,
+  key: K,
+): A[K] extends IOE.IOEither<infer E, infer B>
+  ? RTE.ReaderTaskEither<$H.Has<A>, E, B>
+  : never =>
+  pipe(
+    read(tag),
+    RTE.chainIOEitherKW((a) => a[key] as any),
+  ) as any
+
+export const readsTask = <
+  A extends $S.Struct,
+  K extends ValueOf<{
+    [K in keyof A]: A[K] extends T.Task<unknown> ? K : never
+  }>,
+>(
+  tag: $H.Tag<A>,
+  key: K,
+): A[K] extends T.Task<infer B>
+  ? RTE.ReaderTaskEither<$H.Has<A>, never, B>
+  : never =>
+  pipe(
+    read(tag),
+    RTE.chainTaskK((a) => a[key] as any),
+  ) as any
+
+export const readsTaskEither = <
+  A extends $S.Struct,
+  K extends ValueOf<{
+    [K in keyof A]: A[K] extends TE.TaskEither<unknown, unknown> ? K : never
+  }>,
+>(
+  tag: $H.Tag<A>,
+  key: K,
+): A[K] extends TE.TaskEither<infer E, infer B>
+  ? RTE.ReaderTaskEither<$H.Has<A>, E, B>
+  : never =>
+  pipe(
+    read(tag),
+    RTE.chainTaskEitherKW((a) => a[key] as any),
+  ) as any
+
+export const readsReader = <
+  A extends $S.Struct,
+  K extends ValueOf<{
+    [K in keyof A]: A[K] extends R.Reader<never, unknown> ? K : never
+  }>,
+>(
+  tag: $H.Tag<A>,
+  key: K,
+): A[K] extends R.Reader<infer R, infer B>
+  ? RTE.ReaderTaskEither<R & $H.Has<A>, never, B>
+  : never =>
+  pipe(
+    read(tag),
+    RTE.chainReaderKW((a) => a[key] as any),
+  ) as any
+
+export const readsReaderEither = <
+  A extends $S.Struct,
+  K extends ValueOf<{
+    [K in keyof A]: A[K] extends RE.ReaderEither<never, unknown, unknown>
+      ? K
+      : never
+  }>,
+>(
+  tag: $H.Tag<A>,
+  key: K,
+): A[K] extends RE.ReaderEither<infer R, infer E, infer B>
+  ? RTE.ReaderTaskEither<R & $H.Has<A>, E, B>
+  : never =>
+  pipe(
+    read(tag),
+    RTE.chainReaderEitherKW((a) => a[key] as any),
+  ) as any
+
+export const readsReaderTask = <
+  A extends $S.Struct,
+  K extends ValueOf<{
+    [K in keyof A]: A[K] extends RT.ReaderTask<never, unknown> ? K : never
+  }>,
+>(
+  tag: $H.Tag<A>,
+  key: K,
+): A[K] extends RT.ReaderTask<infer R, infer B>
+  ? RTE.ReaderTaskEither<R & $H.Has<A>, never, B>
+  : never =>
+  pipe(
+    read(tag),
+    RTE.chainReaderTaskKW((a) => a[key] as any),
+  ) as any
+
+export const readsReaderTaskEither = <
+  A extends $S.Struct,
+  K extends ValueOf<{
+    [K in keyof A]: A[K] extends RTE.ReaderTaskEither<never, unknown, unknown>
+      ? K
+      : never
+  }>,
+>(
+  tag: $H.Tag<A>,
+  key: K,
+): A[K] extends RTE.ReaderTaskEither<infer R, infer E, infer B>
+  ? RTE.ReaderTaskEither<R & $H.Has<A>, E, B>
+  : never =>
+  pipe(
+    read(tag),
+    RTE.chainW((a) => a[key] as any),
+  ) as any
+
+export const derive =
+  <A extends (...args: any[]) => any>(tag: $H.Tag<A>) =>
+  (
+    ...args: Parameters<Extract<A, (...args: any[]) => any>>
+  ): A extends (...args: any[]) => infer B
+    ? RTE.ReaderTaskEither<$H.Has<A>, never, B>
+    : never =>
+    pipe(
+      read(tag),
+      RTE.map((f) => f(...args)),
+    ) as any
+
+export const deriveOption =
+  <A extends (...args: any[]) => O.Option<unknown>>(tag: $H.Tag<A>) =>
+  <E>(onNone: Lazy<E>) =>
+  (
+    ...args: Parameters<Extract<A, (...args: any[]) => any>>
+  ): A extends (...args: any[]) => O.Option<infer B>
+    ? RTE.ReaderTaskEither<$H.Has<A>, E, B>
+    : never =>
+    pipe(
+      read(tag),
+      RTE.chainOptionK(onNone)((f) => f(...args)),
+    ) as any
+
+export const deriveEither =
+  <A extends (...args: any[]) => E.Either<unknown, unknown>>(tag: $H.Tag<A>) =>
+  (
+    ...args: Parameters<Extract<A, (...args: any[]) => any>>
+  ): A extends (...args: any[]) => E.Either<infer E, infer B>
+    ? RTE.ReaderTaskEither<$H.Has<A>, E, B>
+    : never =>
+    pipe(
+      read(tag),
+      RTE.chainEitherKW((f) => f(...args)),
+    ) as any
+
+export const deriveIO =
+  <A extends (...args: any[]) => IO.IO<unknown>>(tag: $H.Tag<A>) =>
+  (
+    ...args: Parameters<Extract<A, (...args: any[]) => any>>
+  ): A extends (...args: any[]) => IO.IO<infer B>
+    ? RTE.ReaderTaskEither<$H.Has<A>, never, B>
+    : never =>
+    pipe(
+      read(tag),
+      RTE.chainIOK((f) => f(...args)),
+    ) as any
+
+export const deriveIOEither =
+  <A extends (...args: any[]) => IOE.IOEither<unknown, unknown>>(
+    tag: $H.Tag<A>,
+  ) =>
+  (
+    ...args: Parameters<Extract<A, (...args: any[]) => any>>
+  ): A extends (...args: any[]) => IOE.IOEither<infer E, infer B>
+    ? RTE.ReaderTaskEither<$H.Has<A>, E, B>
+    : never =>
+    pipe(
+      read(tag),
+      RTE.chainIOEitherKW((f) => f(...args)),
+    ) as any
+
+export const deriveTask =
+  <A extends (...args: any[]) => T.Task<unknown>>(tag: $H.Tag<A>) =>
+  (
+    ...args: Parameters<Extract<A, (...args: any[]) => any>>
+  ): A extends (...args: any[]) => T.Task<infer B>
+    ? RTE.ReaderTaskEither<$H.Has<A>, never, B>
+    : never =>
+    pipe(
+      read(tag),
+      RTE.chainTaskK((f) => f(...args)),
+    ) as any
+
+export const deriveTaskEither =
+  <A extends (...args: any[]) => TE.TaskEither<unknown, unknown>>(
+    tag: $H.Tag<A>,
+  ) =>
+  (
+    ...args: Parameters<Extract<A, (...args: any[]) => any>>
+  ): A extends (...args: any[]) => TE.TaskEither<infer E, infer B>
+    ? RTE.ReaderTaskEither<$H.Has<A>, E, B>
+    : never =>
+    pipe(
+      read(tag),
+      RTE.chainTaskEitherKW((f) => f(...args)),
+    ) as any
+
+export const deriveReader =
+  <A extends (...args: any[]) => R.Reader<never, unknown>>(tag: $H.Tag<A>) =>
+  (
+    ...args: Parameters<Extract<A, (...args: any[]) => any>>
+  ): A extends (...args: any[]) => R.Reader<infer R, infer B>
+    ? RTE.ReaderTaskEither<R & $H.Has<A>, never, B>
+    : never =>
+    pipe(
+      read(tag),
+      RTE.chainReaderKW((f) => f(...args)),
+    ) as any
+
+export const deriveReaderEither =
+  <A extends (...args: any[]) => RE.ReaderEither<never, unknown, unknown>>(
+    tag: $H.Tag<A>,
+  ) =>
+  (
+    ...args: Parameters<Extract<A, (...args: any[]) => any>>
+  ): A extends (...args: any[]) => RE.ReaderEither<infer R, infer E, infer B>
+    ? RTE.ReaderTaskEither<R & $H.Has<A>, E, B>
+    : never =>
+    pipe(
+      read(tag),
+      RTE.chainReaderEitherKW((f) => f(...args)),
+    ) as any
+
+export const deriveReaderTask =
+  <A extends (...args: any[]) => RT.ReaderTask<never, unknown>>(
+    tag: $H.Tag<A>,
+  ) =>
+  (
+    ...args: Parameters<Extract<A, (...args: any[]) => any>>
+  ): A extends (...args: any[]) => RT.ReaderTask<infer R, infer B>
+    ? RTE.ReaderTaskEither<R & $H.Has<A>, never, B>
+    : never =>
+    pipe(
+      read(tag),
+      RTE.chainReaderTaskKW((f) => f(...args)),
+    ) as any
+
+export const deriveReaderTaskEither =
+  <A extends (...args: any[]) => RTE.ReaderTaskEither<never, unknown, unknown>>(
+    tag: $H.Tag<A>,
+  ) =>
+  (
+    ...args: Parameters<Extract<A, (...args: any[]) => any>>
+  ): A extends (
+    ...args: any[]
+  ) => RTE.ReaderTaskEither<infer R, infer E, infer B>
+    ? RTE.ReaderTaskEither<R & $H.Has<A>, E, B>
+    : never =>
+    pipe(
+      read(tag),
+      RTE.chainW((f) => f(...args)),
+    ) as any
+
+export const derives =
+  <
+    A extends $S.Struct,
+    K extends ValueOf<{
+      [K in keyof A]: A[K] extends (...args: any[]) => any ? K : never
+    }>,
+  >(
+    tag: $H.Tag<A>,
+    key: K,
+  ) =>
+  (
+    ...args: Parameters<Extract<A[K], (...args: any[]) => any>>
+  ): A[K] extends (...args: any[]) => infer B
+    ? RTE.ReaderTaskEither<$H.Has<A>, never, B>
+    : never =>
+    pipe(
+      reads(tag, key),
+      RTE.map((f) => (f as any)(...args)),
+    ) as any
+
+export const derivesOption =
+  <
+    A extends $S.Struct,
+    K extends ValueOf<{
+      [K in keyof A]: A[K] extends (...args: any[]) => O.Option<unknown>
+        ? K
+        : never
+    }>,
+  >(
+    tag: $H.Tag<A>,
+    key: K,
+  ) =>
+  <E>(onNone: Lazy<E>) =>
+  (
+    ...args: Parameters<Extract<A[K], (...args: any[]) => any>>
+  ): A[K] extends (...args: any[]) => O.Option<infer B>
+    ? RTE.ReaderTaskEither<$H.Has<A>, E, B>
+    : never =>
+    pipe(
+      reads(tag, key),
+      RTE.chainOptionK(onNone)((f) => (f as any)(...args)),
+    ) as any
+
+export const derivesEither =
+  <
+    A extends $S.Struct,
+    K extends ValueOf<{
+      [K in keyof A]: A[K] extends (
+        ...args: any[]
+      ) => E.Either<unknown, unknown>
+        ? K
+        : never
+    }>,
+  >(
+    tag: $H.Tag<A>,
+    key: K,
+  ) =>
+  (
+    ...args: Parameters<Extract<A[K], (...args: any[]) => any>>
+  ): A[K] extends (...args: any[]) => E.Either<infer E, infer B>
+    ? RTE.ReaderTaskEither<$H.Has<A>, E, B>
+    : never =>
+    pipe(
+      reads(tag, key),
+      RTE.chainEitherKW((f) => (f as any)(...args)),
+    ) as any
+
+export const derivesIO =
+  <
+    A extends $S.Struct,
+    K extends ValueOf<{
+      [K in keyof A]: A[K] extends (...args: any[]) => IO.IO<unknown>
+        ? K
+        : never
+    }>,
+  >(
+    tag: $H.Tag<A>,
+    key: K,
+  ) =>
+  (
+    ...args: Parameters<Extract<A[K], (...args: any[]) => any>>
+  ): A[K] extends (...args: any[]) => IO.IO<infer B>
+    ? RTE.ReaderTaskEither<$H.Has<A>, never, B>
+    : never =>
+    pipe(
+      reads(tag, key),
+      RTE.chainIOK((f) => (f as any)(...args)),
+    ) as any
+
+export const derivesIOEither =
+  <
+    A extends $S.Struct,
+    K extends ValueOf<{
+      [K in keyof A]: A[K] extends (
+        ...args: any[]
+      ) => IOE.IOEither<unknown, unknown>
+        ? K
+        : never
+    }>,
+  >(
+    tag: $H.Tag<A>,
+    key: K,
+  ) =>
+  (
+    ...args: Parameters<Extract<A[K], (...args: any[]) => any>>
+  ): A[K] extends (...args: any[]) => IOE.IOEither<infer E, infer B>
+    ? RTE.ReaderTaskEither<$H.Has<A>, E, B>
+    : never =>
+    pipe(
+      reads(tag, key),
+      RTE.chainIOEitherKW((f) => (f as any)(...args)),
+    ) as any
+
+export const derivesTask =
+  <
+    A extends $S.Struct,
+    K extends ValueOf<{
+      [K in keyof A]: A[K] extends (...args: any[]) => T.Task<unknown>
+        ? K
+        : never
+    }>,
+  >(
+    tag: $H.Tag<A>,
+    key: K,
+  ) =>
+  (
+    ...args: Parameters<Extract<A[K], (...args: any[]) => any>>
+  ): A[K] extends (...args: any[]) => T.Task<infer B>
+    ? RTE.ReaderTaskEither<$H.Has<A>, never, B>
+    : never =>
+    pipe(
+      reads(tag, key),
+      RTE.chainTaskK((f) => (f as any)(...args)),
+    ) as any
+
+export const derivesTaskEither =
+  <
+    A extends $S.Struct,
+    K extends ValueOf<{
+      [K in keyof A]: A[K] extends (
+        ...args: any[]
+      ) => TE.TaskEither<unknown, unknown>
+        ? K
+        : never
+    }>,
+  >(
+    tag: $H.Tag<A>,
+    key: K,
+  ) =>
+  (
+    ...args: Parameters<Extract<A[K], (...args: any[]) => any>>
+  ): A[K] extends (...args: any[]) => TE.TaskEither<infer E, infer B>
+    ? RTE.ReaderTaskEither<$H.Has<A>, E, B>
+    : never =>
+    pipe(
+      reads(tag, key),
+      RTE.chainTaskEitherKW((f) => (f as any)(...args)),
+    ) as any
+
+export const derivesReader =
+  <
+    A extends $S.Struct,
+    K extends ValueOf<{
+      [K in keyof A]: A[K] extends (...args: any[]) => R.Reader<never, unknown>
+        ? K
+        : never
+    }>,
+  >(
+    tag: $H.Tag<A>,
+    key: K,
+  ) =>
+  (
+    ...args: Parameters<Extract<A[K], (...args: any[]) => any>>
+  ): A[K] extends (...args: any[]) => R.Reader<infer R, infer B>
+    ? RTE.ReaderTaskEither<R & $H.Has<A>, never, B>
+    : never =>
+    pipe(
+      reads(tag, key),
+      RTE.chainReaderKW((f) => (f as any)(...args)),
+    ) as any
+
+export const derivesReaderEither =
+  <
+    A extends $S.Struct,
+    K extends ValueOf<{
+      [K in keyof A]: A[K] extends (
+        ...args: any[]
+      ) => RE.ReaderEither<never, unknown, unknown>
+        ? K
+        : never
+    }>,
+  >(
+    tag: $H.Tag<A>,
+    key: K,
+  ) =>
+  (
+    ...args: Parameters<Extract<A[K], (...args: any[]) => any>>
+  ): A[K] extends (...args: any[]) => RE.ReaderEither<infer R, infer E, infer B>
+    ? RTE.ReaderTaskEither<R & $H.Has<A>, E, B>
+    : never =>
+    pipe(
+      reads(tag, key),
+      RTE.chainReaderEitherKW((f) => (f as any)(...args)),
+    ) as any
+
+export const derivesReaderTask =
+  <
+    A extends $S.Struct,
+    K extends ValueOf<{
+      [K in keyof A]: A[K] extends (
+        ...args: any[]
+      ) => RT.ReaderTask<never, unknown>
+        ? K
+        : never
+    }>,
+  >(
+    tag: $H.Tag<A>,
+    key: K,
+  ) =>
+  (
+    ...args: Parameters<Extract<A[K], (...args: any[]) => any>>
+  ): A[K] extends (...args: any[]) => RT.ReaderTask<infer R, infer B>
+    ? RTE.ReaderTaskEither<R & $H.Has<A>, never, B>
+    : never =>
+    pipe(
+      reads(tag, key),
+      RTE.chainReaderTaskKW((f) => (f as any)(...args)),
+    ) as any
+
+export const derivesReaderTaskEither =
+  <
+    A extends $S.Struct,
+    K extends ValueOf<{
+      [K in keyof A]: A[K] extends (
+        ...args: any[]
+      ) => RTE.ReaderTaskEither<never, unknown, unknown>
+        ? K
+        : never
+    }>,
+  >(
+    tag: $H.Tag<A>,
+    key: K,
+  ) =>
+  (
+    ...args: Parameters<Extract<A[K], (...args: any[]) => any>>
+  ): A[K] extends (
+    ...args: any[]
+  ) => RTE.ReaderTaskEither<infer R, infer E, infer B>
+    ? RTE.ReaderTaskEither<R & $H.Has<A>, E, B>
+    : never =>
+    pipe(
+      reads(tag, key),
+      RTE.chainW((f) => (f as any)(...args)),
+    ) as any

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,6 +33,8 @@ import * as $type from './Type'
 import * as $validation from './Validation'
 import * as $yield from './Yield'
 
+export type ValueOf<A> = A[keyof A]
+
 export type PartialDeep<A> = A extends { readonly [x: string]: unknown }
   ? Partial<{ readonly [K in keyof A]: PartialDeep<A[K]> }>
   : A

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ import * as $date from './Date'
 import * as $eq from './Eq'
 import * as $error from './Error'
 import * as _$generatorL from './GeneratorL'
+import * as $has from './Has'
 import * as $http from './Http'
 import * as $log from './Log'
 import * as $magma from './Magma'
@@ -67,6 +68,7 @@ export {
   $eq,
   $error,
   $generatorL,
+  $has,
   $http,
   $log,
   $magma,


### PR DESCRIPTION
Taking inspiration from [Effect-TS](https://www.matechs.com/open-source), I've added the `Has` module and some `read*` and `derive*` functions to `ReaderTaskEither` module (other `Reader*` modules could receive them in the future) the help with dependencies management.

Currently, the best way is to define an `Environment` interface, and use `pick*` functions to select single slices. `Has` allows defining dependencies from the bottom, making each service compose its dependencies into the final `ReaderTaskEither` (see `CHANGELOG.md` for an example).