### PR TITLE
Add collectWithIndex function to ReadonlyRecord module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Added
 
-- Add `collectWithPreservedIndex` to `ReadonlyRecord` module.
+- Add `collectWithPreservedIndex` function to `ReadonlyRecord` module.
 
 ## [0.1.5](https://github.com/facile-it/fortepiano/compare/v0.1.4...v0.1.5) - 2022-09-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Added
 
-- Add `collectWithPreservedIndex` function to `ReadonlyRecord` module.
+- Add `collectWithIndex` function to `ReadonlyRecord` module.
 
 ## [0.1.5](https://github.com/facile-it/fortepiano/compare/v0.1.4...v0.1.5) - 2022-09-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+
+- Add `collectWithPreservedIndex` to `ReadonlyRecord` module.
+
 ## [0.1.5](https://github.com/facile-it/fortepiano/compare/v0.1.4...v0.1.5) - 2022-09-22
 
 ### Added

--- a/src/ReadonlyRecord.test.ts
+++ b/src/ReadonlyRecord.test.ts
@@ -1,9 +1,9 @@
 import { pipe } from 'fp-ts/function'
 import * as RR from 'fp-ts/ReadonlyRecord'
-import { collectWithPreservedIndex, values } from './ReadonlyRecord'
+import { collectWithIndex, values } from './ReadonlyRecord'
 
 describe('ReadonlyRecord', () => {
-  describe('collectWithPreservedIndex', () => {
+  describe('collectWithIndex', () => {
     it('should resolve generic records into an array of indexed values', () => {
       ;(
         [
@@ -49,7 +49,7 @@ describe('ReadonlyRecord', () => {
           ],
         ] as Array<[any, Array<any>]>
       ).forEach(([record, expected]) =>
-        expect(collectWithPreservedIndex((_, v) => v)(record)).toEqual(
+        expect(collectWithIndex((_, v) => v)(record)).toEqual(
           expected,
         ),
       )

--- a/src/ReadonlyRecord.test.ts
+++ b/src/ReadonlyRecord.test.ts
@@ -1,69 +1,71 @@
-import { pipe } from "fp-ts/function";
-import * as RR from "fp-ts/ReadonlyRecord";
-import { collectWithPreservedIndex, values } from "./ReadonlyRecord";
+import { pipe } from 'fp-ts/function'
+import * as RR from 'fp-ts/ReadonlyRecord'
+import { collectWithPreservedIndex, values } from './ReadonlyRecord'
 
-describe("ReadonlyRecord", () => {
-  describe("collectWithPreservedIndex", () => {
-    it("should resolve generic records into an array of indexed values", () => {
-      ([
-        [{}, []],
+describe('ReadonlyRecord', () => {
+  describe('collectWithPreservedIndex', () => {
+    it('should resolve generic records into an array of indexed values', () => {
+      ;(
         [
-          {
-            key1: "val1",
-            key2: "val2"
-          },
-          ["val1", "val2"]
-        ],
-        [
-          {
-            key1_min: { something: 1 },
-            key1_max: { something: 2 }
-          },
-          [{ something: 1 }, { something: 2 }]
-        ],
-        [
-          {
-            key1_min: { something: 1 },
-            key1_max: { something: 2 },
-            key2: "key2",
-            key3_max: { key3max: 10 },
-            key3_min: { key3min: 0 }
-          },
+          [{}, []],
           [
-            { something: 1 },
-            { something: 2 },
-            "key2",
-            { key3max: 10 },
-            { key3min: 0 }
-          ]
-        ],
-        [
-          {
-            key1_min: null,
-            key1_max: { something: 2 },
-            key2_max: { key3max: 10 },
-            key2_min: null
-          },
-          [null, { something: 2 }, { key3max: 10 }, null]
-        ]
-      ] as Array<[any, Array<any>]>).forEach(([record, expected]) =>
-        expect(
-          collectWithPreservedIndex((_, v) => v)(record)
-        ).toEqual(expected)
-      );
-    });
-  });
+            {
+              key1: 'val1',
+              key2: 'val2',
+            },
+            ['val1', 'val2'],
+          ],
+          [
+            {
+              key1_min: { something: 1 },
+              key1_max: { something: 2 },
+            },
+            [{ something: 1 }, { something: 2 }],
+          ],
+          [
+            {
+              key1_min: { something: 1 },
+              key1_max: { something: 2 },
+              key2: 'key2',
+              key3_max: { key3max: 10 },
+              key3_min: { key3min: 0 },
+            },
+            [
+              { something: 1 },
+              { something: 2 },
+              'key2',
+              { key3max: 10 },
+              { key3min: 0 },
+            ],
+          ],
+          [
+            {
+              key1_min: null,
+              key1_max: { something: 2 },
+              key2_max: { key3max: 10 },
+              key2_min: null,
+            },
+            [null, { something: 2 }, { key3max: 10 }, null],
+          ],
+        ] as Array<[any, Array<any>]>
+      ).forEach(([record, expected]) =>
+        expect(collectWithPreservedIndex((_, v) => v)(record)).toEqual(
+          expected,
+        ),
+      )
+    })
+  })
 
-  describe("values", () => {
-    it("should return a list of record values", () => {
+  describe('values', () => {
+    it('should return a list of record values', () => {
       const x: RR.ReadonlyRecord<string, string> = {
-        a: "foo",
-        b: "bar",
-        c: "mad",
-        d: "max"
-      };
+        a: 'foo',
+        b: 'bar',
+        c: 'mad',
+        d: 'max',
+      }
 
-      expect(pipe(x, values)).toStrictEqual(["foo", "bar", "mad", "max"]);
-    });
-  });
-});
+      expect(pipe(x, values)).toStrictEqual(['foo', 'bar', 'mad', 'max'])
+    })
+  })
+})

--- a/src/ReadonlyRecord.test.ts
+++ b/src/ReadonlyRecord.test.ts
@@ -49,9 +49,7 @@ describe('ReadonlyRecord', () => {
           ],
         ] as Array<[any, Array<any>]>
       ).forEach(([record, expected]) =>
-        expect(collectWithIndex((_, v) => v)(record)).toEqual(
-          expected,
-        ),
+        expect(collectWithIndex((_, v) => v)(record)).toEqual(expected),
       )
     })
   })

--- a/src/ReadonlyRecord.test.ts
+++ b/src/ReadonlyRecord.test.ts
@@ -1,18 +1,69 @@
-import { pipe } from 'fp-ts/function'
-import * as RR from 'fp-ts/ReadonlyRecord'
-import { values } from './ReadonlyRecord'
+import { pipe } from "fp-ts/function";
+import * as RR from "fp-ts/ReadonlyRecord";
+import { collectWithPreservedIndex, values } from "./ReadonlyRecord";
 
-describe('ReadonlyRecord', () => {
-  describe('values', () => {
-    it('should return a list of record values', () => {
+describe("ReadonlyRecord", () => {
+  describe("collectWithPreservedIndex", () => {
+    it("should resolve generic records into an array of indexed values", () => {
+      ([
+        [{}, []],
+        [
+          {
+            key1: "val1",
+            key2: "val2"
+          },
+          ["val1", "val2"]
+        ],
+        [
+          {
+            key1_min: { something: 1 },
+            key1_max: { something: 2 }
+          },
+          [{ something: 1 }, { something: 2 }]
+        ],
+        [
+          {
+            key1_min: { something: 1 },
+            key1_max: { something: 2 },
+            key2: "key2",
+            key3_max: { key3max: 10 },
+            key3_min: { key3min: 0 }
+          },
+          [
+            { something: 1 },
+            { something: 2 },
+            "key2",
+            { key3max: 10 },
+            { key3min: 0 }
+          ]
+        ],
+        [
+          {
+            key1_min: null,
+            key1_max: { something: 2 },
+            key2_max: { key3max: 10 },
+            key2_min: null
+          },
+          [null, { something: 2 }, { key3max: 10 }, null]
+        ]
+      ] as Array<[any, Array<any>]>).forEach(([record, expected]) =>
+        expect(
+          collectWithPreservedIndex((_, v) => v)(record)
+        ).toEqual(expected)
+      );
+    });
+  });
+
+  describe("values", () => {
+    it("should return a list of record values", () => {
       const x: RR.ReadonlyRecord<string, string> = {
-        a: 'foo',
-        b: 'bar',
-        c: 'mad',
-        d: 'max',
-      }
+        a: "foo",
+        b: "bar",
+        c: "mad",
+        d: "max"
+      };
 
-      expect(pipe(x, values)).toStrictEqual(['foo', 'bar', 'mad', 'max'])
-    })
-  })
-})
+      expect(pipe(x, values)).toStrictEqual(["foo", "bar", "mad", "max"]);
+    });
+  });
+});

--- a/src/ReadonlyRecord.ts
+++ b/src/ReadonlyRecord.ts
@@ -3,7 +3,7 @@ import { pipe } from 'fp-ts/function'
 import * as RR from 'fp-ts/ReadonlyRecord'
 import * as $RA from './ReadonlyArray'
 
-export const collectWithPreservedIndex =
+export const collectWithIndex =
   <K extends string, A, B>(f: (k: K, a: A) => B) =>
   (r: RR.ReadonlyRecord<K, A>): ReadonlyArray<B> =>
     Object.entries(r).map(([k, v]) => f(k as K, v as A))

--- a/src/ReadonlyRecord.ts
+++ b/src/ReadonlyRecord.ts
@@ -3,6 +3,11 @@ import { pipe } from 'fp-ts/function'
 import * as RR from 'fp-ts/ReadonlyRecord'
 import * as $RA from './ReadonlyArray'
 
+export const collectWithPreservedIndex =
+  <K extends string, A, B>(f: (k: K, a: A) => B) =>
+    (r: RR.ReadonlyRecord<K, A>): ReadonlyArray<B> =>
+      Object.entries(r).map(([k, v]) => f(k as K, v as A))
+
 export const values = <A>(as: RR.ReadonlyRecord<string, A>): ReadonlyArray<A> =>
   Object.values(as)
 

--- a/src/ReadonlyRecord.ts
+++ b/src/ReadonlyRecord.ts
@@ -5,8 +5,8 @@ import * as $RA from './ReadonlyArray'
 
 export const collectWithPreservedIndex =
   <K extends string, A, B>(f: (k: K, a: A) => B) =>
-    (r: RR.ReadonlyRecord<K, A>): ReadonlyArray<B> =>
-      Object.entries(r).map(([k, v]) => f(k as K, v as A))
+  (r: RR.ReadonlyRecord<K, A>): ReadonlyArray<B> =>
+    Object.entries(r).map(([k, v]) => f(k as K, v as A))
 
 export const values = <A>(as: RR.ReadonlyRecord<string, A>): ReadonlyArray<A> =>
   Object.values(as)


### PR DESCRIPTION
Added function to `ReadonlyRecord` module to collect values preserving indexes.